### PR TITLE
kakao map api

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=8e50d320a825fe0a258e008547e78d85"></script> <!-- Kakao Map API -->
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -3,9 +3,17 @@ import { animated, interpolate } from "react-spring/hooks";
 import Carousel from "nuka-carousel";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMapMarkerAlt} from '@fortawesome/free-solid-svg-icons';
+import Map from "./Map";
 
 //card 1장에 대한 컴포넌트
 
+/* 현재 카드 뒷면이 없는 관계로 기존 이미지 자리에 지도를 임시로 배치함 
+<Carousel>
+    {pics.map((pic, index) => (
+        <img src={pic} key={index} alt="food_picture" />
+    ))}
+</Carousel> 
+*/
 const Card = ({ i, x, y, rot, scale, trans, bind, data }) => {
   const { name, age, distance, bio, pics } = data[i];
 
@@ -23,12 +31,11 @@ const Card = ({ i, x, y, rot, scale, trans, bind, data }) => {
         }}
       >
         <div className="card">
-          <Carousel>
-            {pics.map((pic, index) => (
-              <img src={pic} key={index} alt="food_picture" />
-            ))}
-          </Carousel>
-          <h2>{name},</h2>
+          <Map
+            i={i}
+            data={data}
+          />
+          <h2>{name}</h2>
           <h2>{age}</h2>
           <h5><FontAwesomeIcon icon={faMapMarkerAlt} /> {distance}</h5>
           <h5>{bio}</h5>
@@ -39,3 +46,4 @@ const Card = ({ i, x, y, rot, scale, trans, bind, data }) => {
 };
 
 export default Card;
+

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,0 +1,34 @@
+/*global kakao*/ 
+import React, { useEffect } from 'react'
+
+const Map=({i, data})=>{
+  const {lat, lng} = data[i];
+  var divId = "map" + i.toString()
+  useEffect(()=>{
+    var container = document.getElementById(divId);
+    var options = {
+      center: new kakao.maps.LatLng(lat, lng),
+      level: 3
+    };
+
+    var map = new kakao.maps.Map(container, options);
+
+    map.setDraggable(false); //드래그 막기
+    map.setZoomable(false); //줌 막기
+
+    var markerPosition  = new kakao.maps.LatLng(lat, lng); 
+    var marker = new kakao.maps.Marker({
+      position: markerPosition
+    });
+    marker.setMap(map);
+
+    }, [lat, lng, divId])
+
+    return (
+        <div>
+            <div id={divId} style={{height: "380px", width: "290px"}}></div>
+        </div>
+    )
+}
+
+export default Map;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -3,9 +3,8 @@ import React, { useEffect } from 'react'
 
 const Map=({i, data})=>{
   const {lat, lng} = data[i];
-  var divId = "map" + i.toString()
   useEffect(()=>{
-    var container = document.getElementById(divId);
+    var container = document.getElementById(`map${i}`);
     var options = {
       center: new kakao.maps.LatLng(lat, lng),
       level: 3
@@ -22,11 +21,11 @@ const Map=({i, data})=>{
     });
     marker.setMap(map);
 
-    }, [lat, lng, divId])
+    }, [lat, lng, i])
 
     return (
         <div>
-            <div id={divId} style={{height: "380px", width: "290px"}}></div>
+            <div id={`map${i}`} style={{height: "380px", width: "290px"}}></div>
         </div>
     )
 }

--- a/src/data.js
+++ b/src/data.js
@@ -4,13 +4,15 @@ export default [
   {
     pics: [
       "https://cdn.vox-cdn.com/thumbor/RX04uAR-GhRdN9-en6PmkSj69iU=/0x0:6080x2546/1200x800/filters:focal(2406x699:3378x1671)/cdn.vox-cdn.com/uploads/chorus_image/image/65753797/elsainfall.0.jpg",
-      "https://vignette.wikia.nocookie.net/disney/images/9/95/Profile_-_Elsa.jpeg/revision/latest?cb=20200319054311"
+      "https://vignette.wikia.nocookie.net/disney/images/9/95/Profile_-_Elsa.jpeg/revision/latest?cb=20200319054311",
     ],
     name: "짬뽕야",
     age: 26,
     distance: "1 mile away",
     bio:
-      "짬뽕야 맛있어"
+      "짬뽕야 맛있어",
+    lat: 37.56874974936244, 
+    lng: 126.99851716537624
   },
   {
     pics: [
@@ -20,7 +22,9 @@ export default [
     name: "은주정",
     age: 28,
     distance: "15 miles away",
-    bio: "은주정 좋아."
+    bio: "은주정 좋아.",
+    lat: 37.56874974936244, 
+    lng: 126.99851716537624
   },
   {
     pics: [
@@ -31,7 +35,9 @@ export default [
     age: 32,
     distance: "9 miles away",
     bio:
-      "직식이 최고야"
+      "직식이 최고야",
+    lat: 37.56874974936244, 
+    lng: 126.99851716537624
   },
   {
     pics: [
@@ -41,18 +47,22 @@ export default [
     name: "리김밥",
     age: 25,
     distance: "3 miles away",
-    bio: "김밥 맛있어😉"
+    bio: "김밥 맛있어😉",
+    lat: 37.56874974936244, 
+    lng: 126.99851716537624
   },
   {
     pics: [
       "https://pbs.twimg.com/media/C8HShn0VwAArWJz.jpg",
-      "https://i.pinimg.com/736x/95/ee/91/95ee91b6d78ef79a317ab9482e135458.jpg"
+      "https://i.pinimg.com/736x/95/ee/91/95ee91b6d78ef79a317ab9482e135458.jpg",
     ],
     name: "미스터빠삭",
     age: 27,
     distance: "2 miles away",
     bio:
-      "너무 빠삭해"
+      "너무 빠삭해",
+    lat: 37.56874974936244, 
+    lng: 126.99851716537624
   }
   
 


### PR DESCRIPTION
1. kakao map api 연결
- 카드 뒷면이 없어서 기존에 이미지 있던 부분 임시로 지우고 넣었습니다.
- 카드 클릭시 뒷면으로 회전된다면 지도부분을 현재 보이는거서럼 뒷면에 띄우면 될듯 (회전안되면 이미지 대신 넣거나 다른 위치 고려 필요)
 - 지도에 드래그가 가능한데, 카드 넘기는 효과에 거슬리는 것 같아 불가능하게 처리해둠 (확대도 막긴했는데 더블클릭하면 확대됨,,;; 사소한 디테일은 마지막에 수정)

2. data.js 수정 @alswn8972 
- 지도 띄울때 필요한 위도`lat`, 경도`lng` 임시 데이터로 채워두었습니다.
- 카카오맵 길찾기로 연결시 url 도 추가 필요함.

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/65571623/190903510-d94dd7da-7559-407c-abd7-7a384670c097.png">